### PR TITLE
chore(template): reject new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.7.0-43-g7bef3d8
+_commit: v0.7.0-51-g32cc95e
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: typer
 conda_channel: wpk-nist


### PR DESCRIPTION
This is an autogenerated PR. Use this to reject the changes in this repository.

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.