### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.13.0-18-g36d2b19
+_commit: v0.13.0-25-gd26a6e6
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: typer
 conda_channel: wpk-nist

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
@@ -107,7 +107,7 @@ jobs:
     if: needs.pre_job.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
@@ -166,7 +166,7 @@ jobs:
         session:
           - typecheck
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-cached-uv-and-python
@@ -217,7 +217,7 @@ jobs:
             session: test-noopt
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -258,7 +258,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - name: Download individual coverage reports

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-cached-uv-and-python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
           echo "OWNER       - $OWNER"
           echo "RELEASE     - $RELEASE"
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/update-copier.yml
+++ b/.github/workflows/update-copier.yml
@@ -43,7 +43,7 @@ jobs:
           #   commit-message: "chore(template): reject new copier update"
           #   title: "chore(template): reject new copier update"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: pull-request
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: ./.github/actions/setup-cached-uv-and-python

--- a/.github/workflows/update-package-version.yml
+++ b/.github/workflows/update-package-version.yml
@@ -37,7 +37,7 @@ jobs:
     environment:
       name: pull-request
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -8,7 +8,7 @@ reorder_keys = true
 
 [[rule]]
 include = [ "**/pyproject.toml" ]
-keys = [ "project", "tool.coverage" ]
+keys = [ "project", "tool.coverage", "tool.mypy.overrides" ]
 
 [rule.formatting]
 reorder_arrays = false

--- a/tools/requirements_lock.py
+++ b/tools/requirements_lock.py
@@ -33,6 +33,10 @@ USE_PYTHON_MIN_VERSION = [
 ]
 USE_NO_DEPS = ["uvx-tools.txt", "pre-commit-additional-dependencies.txt"]
 
+LOCK_SCRIPTS = [
+    "tools/sync_pyproject_min_versions.py",
+]
+
 
 def _get_min_python_version() -> str:
     data: list[str] = (
@@ -142,6 +146,23 @@ def _maybe_lock_or_sync(
     _ = check_call(command)
 
 
+def _lock_scripts(
+    scripts: Iterable[str],
+    upgrade: bool,
+    uv_options: Sequence[str],
+) -> None:
+    for script in scripts:
+        command = [
+            "uv",
+            "lock",
+            f"--script={script}",
+            *(["--upgrade"] if upgrade else []),
+            *uv_options,
+        ]
+        logger.info(shlex.join(command))
+        _ = check_call(command)
+
+
 def _path_or_none(x: str) -> Path | None:
     path = Path(x)
     return path if path.exists() else None
@@ -210,6 +231,15 @@ def main(args: Sequence[str] | None = None) -> int:
         """,
     )
     _ = parser.add_argument(
+        "--script",
+        dest="scripts",
+        default=LOCK_SCRIPTS,
+        action="append",
+        help="""
+        Scripts to lock.
+        """,
+    )
+    _ = parser.add_argument(
         "paths",
         type=Path,
         nargs="*",
@@ -225,6 +255,12 @@ def main(args: Sequence[str] | None = None) -> int:
         lock=opts.lock,
         sync=opts.sync,
         sync_or_lock=opts.sync_or_lock,
+        upgrade=opts.upgrade,
+        uv_options=uv_options,
+    )
+
+    _lock_scripts(
+        scripts=opts.scripts,
         upgrade=opts.upgrade,
         uv_options=uv_options,
     )

--- a/tools/sync_pyproject_min_versions.py.lock
+++ b/tools/sync_pyproject_min_versions.py.lock
@@ -1,0 +1,38 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+sphinxcontrib-typer = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
+typer = { timestamp = "0001-01-01T00:00:00Z", span = "P6D" }
+
+[manifest]
+requirements = [
+    { name = "packaging", specifier = ">=26.2" },
+    { name = "requirements-parser", specifier = ">=0.13.0" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630, upload-time = "2025-05-21T13:42:05.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782, upload-time = "2025-05-21T13:42:04.007Z" },
+]


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .github/workflows/cd.yml
 M .github/workflows/ci.yml
 M .github/workflows/docs.yml
 M .github/workflows/release.yml
 M .github/workflows/update-copier.yml
 M .github/workflows/update-deps.yml
 M .github/workflows/update-package-version.yml
 M .taplo.toml
 M tools/requirements_lock.py

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.