### PR TITLE
chore(template): accept new copier update

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.13.1-19-g9681d41
+_commit: v0.13.1-20-g4b65127
 _src_path: https://github.com/usnistgov/cookiecutter-nist-python.git
 command_line_interface: typer
 conda_channel: wpk-nist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
       - id: taplo-lint
         args: ["--no-schema"]
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.25.4
+    rev: v2.26.0
     hooks:
       - id: pyproject-fmt
   # ** validate (schema-store)

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -21,6 +21,7 @@ keys = [
     "project",
     "tool.coverage",
     "tool.mypy",
+    "tool.pyproject-fmt",
     "tool.pyproject2conda",
     "tool.pyrefly",
     "tool.pyright",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,8 @@ src_dir = [ "src" ]
 toplevel = [ "uv_workon" ]
 
 [tool.pyproject-fmt]
+indent = 4
+keep_full_version = true
 # max_supported_python = "3.13"
 expand_tables = [
     "project.entry-points",
@@ -166,8 +168,6 @@ expand_tables = [
     "tool.uv.dependency-groups",
     "tool.uv.exclude-newer-package",
 ]
-indent = 4
-keep_full_version = true
 
 [tool.typos.default.extend-identifiers]
 CPY = "CPY"


### PR DESCRIPTION
This is an autogenerated PR. Use this to merge the changes to this repository. 

Files changed (`git status --short`):
 M .copier-answers.yml
 M .pre-commit-config.yaml
 M .taplo.toml
 M pyproject.toml

[copier](https://github.com/copier-org/copier) has detected updates from the Cookiecutter repository.